### PR TITLE
feat(Base Setup): add models

### DIFF
--- a/lib/code_style.dart
+++ b/lib/code_style.dart
@@ -1,0 +1,31 @@
+class CodeStyle {
+  const CodeStyle(this.categories);
+
+  final List<Category> categories;
+}
+
+class Category {
+  const Category(this.groups);
+
+  final List<Group> groups;
+}
+
+class Group {
+  const Group(this.cases);
+
+  final List<Case> cases;
+}
+
+class Case {
+  const Case(this.description, this.examples);
+
+  final String description;
+  final List<Example> examples;
+}
+
+class Example {
+  const Example(this.goodAnswer, this.badAnswer);
+
+  final String goodAnswer;
+  final String badAnswer;
+}


### PR DESCRIPTION
This PR introduces the base models to work on, each `CodeStyle`  can have multiple `Category`s, `Group`s and 
`Example`s.

The example markdown that these models model is:

```markdown
      # Category Name 1

      ## Group Name 1

      - Case description 

      ```language-name
        // Avoid
        Bad Example 1
        
        // Prefer
        Good Example 1
        
        // Avoid
        Bad Example 2
        
        // Prefer
        Good Example 2
      ```
```

Fix: https://github.com/danielgomezrico/code_style_tours/issues/4